### PR TITLE
Add search result highlighting

### DIFF
--- a/index.less
+++ b/index.less
@@ -28,6 +28,17 @@
   background-color: rgba(197, 200, 198, 0.1);
 }
 
+atom-text-editor .find-result .region,
+atom-text-editor::shadow .find-result .region {
+  border: 1px solid #F8F8F0;
+}
+
+atom-text-editor .current-result .region,
+atom-text-editor::shadow .current-result .region {
+  background-color: #444444;
+  border: 1px solid #F8F8F0;
+}
+
 .comment {
   color: #75715E;
 }


### PR DESCRIPTION
It was previously very hard (and sometimes seemed impossible) to determine what matched your search term when performing a search.

I couldn't find any official documentation on what the best way to target the `.find-result .region` and the `.find-result.current-result .region` items but the full selectors (including the `atom-text-editor` initial quantifier) are necessary from what I can tell. If you attempt to use `:host` instead of `atom-text-editor`, not everything can be overridden (without a `!important` which seems very bad).

Here is what a find looks like now with this fix:
![screen shot 2015-01-07 at 5 50 54 pm](https://cloud.githubusercontent.com/assets/66679/5656725/fe10cfe6-9695-11e4-9164-9b8d433ad35a.png)

Here is what it looked like previously:
![screen shot 2015-01-07 at 5 57 56 pm](https://cloud.githubusercontent.com/assets/66679/5656771/cec4782c-9696-11e4-906c-d20a58c1fbf4.png)
